### PR TITLE
bugfix: prevent multiple version specs in metadata

### DIFF
--- a/tina/cookbook_metadata.py
+++ b/tina/cookbook_metadata.py
@@ -75,7 +75,7 @@ class CookbookMetadata:
                                     % cookbook)
                 else:
                     version = versions[cookbook].version_str()
-                    line = re.sub("[\'\"]%s[\'\"]" % cookbook,
+                    line = re.sub("[\'\"]%s[\'\"].*" % cookbook,
                         "\"%s\", \"= %s\"" % (cookbook, version), line)
             new_content.append(line)
 


### PR DESCRIPTION
This is not supposed to be in a chef cookbook metadata.rb file:

``` ruby
depends "yum" "= 2.4.3" "~> 2.0"
```
